### PR TITLE
fix: storeInfo 매핑 오류 수정

### DIFF
--- a/src/main/resources/mapper/store/StoreCategoryMapper.xml
+++ b/src/main/resources/mapper/store/StoreCategoryMapper.xml
@@ -10,7 +10,7 @@
         property="storeInfo" 
         column="store_info_id"
         javaType="StoreInfo"
-        select="com.intellimarket.store.dao.StoreInfoDAO.select"
+        select="com.intellimarket.store.dao.StoreInfoDAO.selectById"
     	/>
         
         <association 
@@ -25,7 +25,7 @@
 	<resultMap id="storeCategoryFullMap" type="StoreCategory">
 		<id column="store_category_id" property="storeCategoryId" />
 		<association property="storeInfo" column="store_info_id"
-			javaType="StoreInfo" select="com.intellimarket.store.dao.StoreInfoDAO.select" />
+			javaType="StoreInfo" select="com.intellimarket.store.dao.StoreInfoDAO.selectById" />
 		<association property="subCategory" javaType="SubCategory">
 			<id column="sub_category_id" property="subCategoryId" />
 			<result column="sub_category_name" property="categoryName" />


### PR DESCRIPTION
StoreInfoDAO에

select
selectById 가 중복으로 들어가있어, select를 삭제했으며
StoreInfoMapper에서 select를 참조하고 있어 예외가 발생한 문제 해결하였습니다.